### PR TITLE
Fix mobile navigation hydration and add E2E coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Beehiiv credentials are required at server startup. Replace these values to
+# test newsletter subscriptions locally. The placeholders are safe for E2E tests.
+BEEHIIV_API_KEY=e2e-test
+BEEHIIV_PUBLICATION_ID=e2e-test
+
+# Secret used to sign the color-scheme cookie.
+COOKIE_SECRET=secret
+
+# Local origin used when a request URL is unavailable.
+SITE_ORIGIN=http://localhost:5173

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Mobile navigation E2E
+    runs-on: ubuntu-latest
+    env:
+      BEEHIIV_API_KEY: e2e-test
+      BEEHIIV_PUBLICATION_ID: e2e-test
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
   e2e:
     name: Mobile navigation E2E
     runs-on: ubuntu-latest
-    env:
-      BEEHIIV_API_KEY: e2e-test
-      BEEHIIV_PUBLICATION_ID: e2e-test
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -27,6 +24,10 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Copy test env vars
+        run: |
+          cp .env.example .env
+          grep -v '^#' .env.example | grep -v '^\s*$' >> "$GITHUB_ENV"
       - name: Install Playwright Chromium
         run: npx playwright install chromium --with-deps
       - run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .env
 /.vercel/
 estimates/
+/playwright-report/
+/test-results/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Install the dependencies:
 
 ```bash
 npm install
+cp .env.example .env
 ```
 
 ### Development

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,0 +1,79 @@
+import { PassThrough } from "node:stream";
+import { createReadableStreamFromReadable } from "@react-router/node";
+import { isbot } from "isbot";
+import type { RenderToPipeableStreamOptions } from "react-dom/server";
+import { renderToPipeableStream } from "react-dom/server";
+import type { EntryContext } from "react-router";
+import { ServerRouter } from "react-router";
+
+import { init } from "~/lib/env.server";
+
+init();
+
+export const streamTimeout = 5000;
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+) {
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, {
+      headers: responseHeaders,
+      status: responseStatusCode,
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const userAgent = request.headers.get("user-agent");
+
+    const readyOption: keyof RenderToPipeableStreamOptions =
+      (userAgent && isbot(userAgent)) || routerContext.isSpaMode
+        ? "onAllReady"
+        : "onShellReady";
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(
+      () => abort(),
+      streamTimeout + 1000,
+    );
+
+    const { pipe, abort } = renderToPipeableStream(
+      <ServerRouter context={routerContext} url={request.url} />,
+      {
+        [readyOption]() {
+          shellRendered = true;
+          const body = new PassThrough({
+            final(callback) {
+              clearTimeout(timeoutId);
+              timeoutId = undefined;
+              callback();
+            },
+          });
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set("Content-Type", "text/html");
+
+          pipe(body);
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+      },
+    );
+  });
+}

--- a/app/features/blog/beehiiv.server.ts
+++ b/app/features/blog/beehiiv.server.ts
@@ -1,10 +1,8 @@
 import axios from "axios";
-import invariant from "tiny-invariant";
 
-const { BEEHIIV_API_KEY, BEEHIIV_PUBLICATION_ID } = process.env;
+import { getEnv } from "~/lib/env.server";
 
-invariant(BEEHIIV_API_KEY, "BEEHIIV_API_KEY is not set");
-invariant(BEEHIIV_PUBLICATION_ID, "BEEHIIV_PUBLICATION_ID is not set");
+const { BEEHIIV_API_KEY, BEEHIIV_PUBLICATION_ID } = getEnv();
 
 const api = axios.create({
   baseURL: "https://api.beehiiv.com/v2",

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -1,0 +1,46 @@
+import "dotenv/config";
+
+import { z } from "zod";
+
+const schema = z.object({
+  BEEHIIV_API_KEY: z.string().min(1),
+  BEEHIIV_PUBLICATION_ID: z.string().min(1),
+  COOKIE_SECRET: z.string().min(1).default("secret"),
+  NODE_ENV: z.enum(["production", "development", "test"] as const),
+  SITE_ORIGIN: z.url().optional(),
+  VERCEL_URL: z.string().min(1).optional(),
+});
+
+type Env = z.infer<typeof schema>;
+
+let environment: Env | undefined;
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends Omit<Env, "NODE_ENV"> {}
+  }
+}
+
+export function getEnv() {
+  if (environment) {
+    return environment;
+  }
+
+  const parsed = schema.safeParse(process.env);
+
+  if (!parsed.success) {
+    console.error(
+      "Invalid environment variables:",
+      z.flattenError(parsed.error).fieldErrors,
+    );
+
+    throw new Error("Invalid environment variables");
+  }
+
+  environment = parsed.data;
+  return environment;
+}
+
+export function init() {
+  getEnv();
+}

--- a/app/lib/misc.ts
+++ b/app/lib/misc.ts
@@ -1,5 +1,3 @@
-import "dotenv/config";
-
 /**
  * Extracts the slug from a blog URL.
  *
@@ -90,27 +88,18 @@ export const getSocialsMeta = ({
  * @returns The domain URL as a string.
  * @throws {Error} If the host cannot be determined from the request headers.
  */
-const environmentOrigin = process.env.VERCEL_URL
-  ? // Vercel: VERCEL_URL is like "my-site.vercel.app" or with protocol
-    process.env.VERCEL_URL.startsWith("http")
-    ? process.env.VERCEL_URL
-    : `https://${process.env.VERCEL_URL}`
-  : process.env.SITE_ORIGIN; // e.g. "http://localhost:5173"
-
 export function getDomainUrl(request: Request): string {
-  // 1) Env var override
+  const environmentOrigin = getEnvironmentOrigin();
   if (environmentOrigin) {
     return removeTrailingSlash(environmentOrigin);
   }
 
-  // 2) Derive from the request URL (works in prerender & real requests)
   try {
     return new URL(request.url).origin;
   } catch {
-    // ignore parse errors
+    // Fall back to the forwarded host headers.
   }
 
-  // 3) Fallback to headers
   const host =
     request.headers.get("X-Forwarded-Host") ?? request.headers.get("host");
   if (!host) {
@@ -119,8 +108,22 @@ export function getDomainUrl(request: Request): string {
         "Set VERCEL_URL (on Vercel) or SITE_ORIGIN (locally) if needed.",
     );
   }
+
   const protocol = host.includes("localhost") ? "http" : "https";
   return `${protocol}://${host}`;
+}
+
+function getEnvironmentOrigin() {
+  if (typeof process === "undefined") {
+    return undefined;
+  }
+
+  const { SITE_ORIGIN, VERCEL_URL } = process.env;
+  if (!VERCEL_URL) {
+    return SITE_ORIGIN;
+  }
+
+  return VERCEL_URL.startsWith("http") ? VERCEL_URL : `https://${VERCEL_URL}`;
 }
 
 /**

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,7 +17,12 @@ import {
 
 import type { Route } from "./+types/root";
 import { Button, buttonVariants } from "./components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "./components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "./components/ui/sheet";
 import { getColorScheme } from "./features/color-scheme/color-scheme.server";
 import { ColorSchemeScript } from "./features/color-scheme/color-scheme-script";
 import { useColorScheme } from "./features/color-scheme/use-color-scheme";
@@ -155,7 +160,13 @@ export function Layout({ children }: { children: ReactNode }) {
                 </Button>
               </SheetTrigger>
 
-              <SheetContent className="p-6" side="left">
+              <SheetContent
+                aria-describedby={undefined}
+                className="p-6"
+                side="left"
+              >
+                <SheetTitle className="sr-only">Navigation menu</SheetTitle>
+
                 <nav className="grid gap-6 text-lg font-medium">
                   {navLinks.map((link) => (
                     <NavLink

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.2",
         "@mdx-js/rollup": "^3.1.1",
+        "@playwright/test": "^1.61.1",
         "@react-router/dev": "^7.18.1",
         "@tailwindcss/vite": "^4.3.2",
         "@types/node": "^26",
@@ -1330,6 +1331,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8012,6 +8029,53 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "shiki": "^4.3.1",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "tiny-invariant": "^1.3.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -9325,12 +9324,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "shiki": "^4.3.1",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "tiny-invariant": "^1.3.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@mdx-js/rollup": "^3.1.1",
+    "@playwright/test": "^1.61.1",
     "@react-router/dev": "^7.18.1",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26",
@@ -57,6 +58,9 @@
     "format": "biome format --write .",
     "lint": "biome ci .",
     "start": "react-router-serve ./build/server/index.js",
+    "start:e2e": "vite preview --host 127.0.0.1 --port 4173 --strictPort --outDir build/client",
+    "test:e2e": "npm run build && playwright test",
+    "test:e2e:ui": "npm run build && playwright test --ui",
     "typecheck": "react-router typegen && tsc"
   },
   "type": "module",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const isCI = !!process.env.CI;
+const baseURL = "http://127.0.0.1:4173";
+
+export default defineConfig({
+  forbidOnly: isCI,
+  fullyParallel: true,
+  projects: [
+    {
+      name: "mobile-chromium",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+  reporter: isCI ? [["html"], ["github"]] : [["html"]],
+  retries: isCI ? 2 : 0,
+  testDir: "./playwright",
+  testMatch: "*.e2e.ts",
+  use: {
+    baseURL,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run start:e2e",
+    reuseExistingServer: !isCI,
+    url: baseURL,
+  },
+  workers: isCI ? 1 : undefined,
+});

--- a/playwright/mobile-navigation.e2e.ts
+++ b/playwright/mobile-navigation.e2e.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+test("given: a visitor on mobile, should: open the navigation menu", async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await page.goto("/");
+
+  const menuButton = page.getByRole("button", {
+    name: "Toggle navigation menu",
+  });
+  await expect(menuButton).toBeVisible();
+  expect(pageErrors).toEqual([]);
+
+  await menuButton.click();
+
+  const menu = page.getByRole("dialog");
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole("link", { name: "Blog" })).toBeVisible();
+
+  await menu.getByRole("button", { name: "Close" }).click();
+
+  await expect(menu).toBeHidden();
+  expect(pageErrors).toEqual([]);
+});

--- a/playwright/mobile-navigation.e2e.ts
+++ b/playwright/mobile-navigation.e2e.ts
@@ -16,7 +16,7 @@ test("given: a visitor on mobile, should: open the navigation menu", async ({
 
   await menuButton.click();
 
-  const menu = page.getByRole("dialog");
+  const menu = page.getByRole("dialog", { name: "Navigation menu" });
   await expect(menu).toBeVisible();
   await expect(menu.getByRole("link", { name: "Blog" })).toBeVisible();
 


### PR DESCRIPTION
## Summary

- Keep dotenv out of the browser bundle so React can hydrate the mobile menu.
- Add a Playwright mobile Chromium regression that opens and closes the drawer and catches browser errors.
- Run the production build and E2E test in GitHub Actions on pushes and pull requests to main.
- Upload the Playwright report for CI diagnosis.

## Red-green verification

- With the faulty dotenv import restored, the test failed with: process is not defined.
- With the fix restored, the unchanged test passed: 1 passed (4.0s).

## Checks

- npm run lint
- npm run typecheck
- npm run test:e2e